### PR TITLE
Add basic read-only WordGraph for FroidurePin

### DIFF
--- a/deps/src/CMakeLists.txt
+++ b/deps/src/CMakeLists.txt
@@ -33,6 +33,7 @@ message(STATUS "libsemigroups libraries: ${LIBSEMIGROUPS_LIBRARIES}")
 add_library(libsemigroups_julia SHARED
     libsemigroups_julia.cpp
     constants.cpp
+    word-graph.cpp
     transf.cpp
 )
 

--- a/deps/src/libsemigroups_julia.cpp
+++ b/deps/src/libsemigroups_julia.cpp
@@ -28,10 +28,11 @@ JLCXX_MODULE define_julia_module(jl::Module & mod)
   // Define constants first (UNDEFINED, POSITIVE_INFINITY, etc.)
   define_constants(mod);
 
+  // Define WordGraph (must be before FroidurePinBase later)
+  define_word_graph(mod);
+
   // Define element types
   define_transf(mod);
-
-  // Add more definitions here (FroidurePin, etc.)
 }
 
 }    // namespace libsemigroups_julia

--- a/deps/src/libsemigroups_julia.hpp
+++ b/deps/src/libsemigroups_julia.hpp
@@ -51,6 +51,12 @@
 // Index conversion utilities (1-based ↔ 0-based)
 #include "index_utils.hpp"
 
+// CxxWrap type traits — non-Julia C++ types must opt out of mirroring
+namespace jlcxx {
+template <>
+struct IsMirroredType<libsemigroups::WordGraph<uint32_t>> : std::false_type {};
+}    // namespace jlcxx
+
 namespace libsemigroups_julia {
 
 // Namespace aliases for convenience

--- a/deps/src/libsemigroups_julia.hpp
+++ b/deps/src/libsemigroups_julia.hpp
@@ -29,6 +29,7 @@
 // libsemigroups headers
 #include <libsemigroups/constants.hpp>
 #include <libsemigroups/types.hpp>
+#include <libsemigroups/word-graph.hpp>
 
 // Standard library
 #include <sstream>
@@ -44,6 +45,7 @@ namespace libsemigroups = ::libsemigroups;
 
 // Forward declarations of binding functions
 void define_constants(jl::Module & mod);
+void define_word_graph(jl::Module & mod);
 void define_transf(jl::Module & mod);
 
 }    // namespace libsemigroups_julia

--- a/deps/src/word-graph.cpp
+++ b/deps/src/word-graph.cpp
@@ -1,0 +1,128 @@
+//
+// Semigroups.jl
+// Copyright (C) 2026, James W. Swent
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "libsemigroups_julia.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+namespace libsemigroups_julia {
+
+void define_word_graph(jl::Module & m)
+{
+  using WG = libsemigroups::WordGraph<uint32_t>;
+
+  auto type = m.add_type<WG>("WordGraph");
+
+  //////////////////////////////////////////////////////////////////////////
+  // Constructor
+  //////////////////////////////////////////////////////////////////////////
+
+  m.method("WordGraph", [](size_t num_nodes, size_t out_deg) -> WG {
+    return WG(num_nodes, out_deg);
+  });
+
+  //////////////////////////////////////////////////////////////////////////
+  // Size / structure queries
+  //////////////////////////////////////////////////////////////////////////
+
+  // number_of_nodes - total number of nodes in the graph
+  type.method("number_of_nodes", &WG::number_of_nodes);
+
+  // out_degree - number of edge labels (same for all nodes)
+  type.method("out_degree", &WG::out_degree);
+
+  // number_of_edges - total number of defined edges (all nodes)
+  type.method("number_of_edges", [](WG const & self) -> size_t {
+    return self.number_of_edges();
+  });
+
+  // number_of_edges_node - number of defined edges from a specific node
+  type.method("number_of_edges_node", [](WG const & self, uint32_t s) -> size_t {
+    return self.number_of_edges(s);
+  });
+
+  //////////////////////////////////////////////////////////////////////////
+  // Edge lookup
+  //////////////////////////////////////////////////////////////////////////
+
+  // target - get the target of edge (source, label).
+  // Returns UNDEFINED (as uint32_t max) if no such edge is defined.
+  type.method("target", [](WG const & self, uint32_t source, uint32_t label) -> uint32_t {
+    return self.target(source, label);
+  });
+
+  // next_label_and_target - find next defined edge from node s with label >= a.
+  // Split into two methods to avoid std::pair which CxxWrap can't return.
+  // next_label: returns the label of the next defined edge (UNDEFINED if none)
+  // next_target: returns the target of the next defined edge (UNDEFINED if none)
+  type.method("next_label", [](WG const & self, uint32_t s, uint32_t a) -> uint32_t {
+    return self.next_label_and_target(s, a).first;
+  });
+  type.method("next_target", [](WG const & self, uint32_t s, uint32_t a) -> uint32_t {
+    return self.next_label_and_target(s, a).second;
+  });
+
+  //////////////////////////////////////////////////////////////////////////
+  // Iteration helpers (collect to vector for CxxWrap)
+  //////////////////////////////////////////////////////////////////////////
+
+  // targets_vector - all targets from a given source node as a vector.
+  // Includes UNDEFINED entries for labels with no defined edge.
+  type.method(
+      "targets_vector", [](WG const & self, uint32_t source) -> std::vector<uint32_t> {
+        std::vector<uint32_t> result;
+        result.reserve(self.out_degree());
+        for (auto it = self.cbegin_targets(source); it != self.cend_targets(source); ++it)
+        {
+          result.push_back(*it);
+        }
+        return result;
+      });
+
+  //////////////////////////////////////////////////////////////////////////
+  // Comparison
+  //////////////////////////////////////////////////////////////////////////
+
+  type.method("is_equal", [](WG const & a, WG const & b) -> bool {
+    return a == b;
+  });
+  type.method("is_not_equal", [](WG const & a, WG const & b) -> bool {
+    return a != b;
+  });
+  type.method("is_less", [](WG const & a, WG const & b) -> bool {
+    return a < b;
+  });
+
+  //////////////////////////////////////////////////////////////////////////
+  // Copy and hash
+  //////////////////////////////////////////////////////////////////////////
+
+  // copy - returns a deep copy
+  type.method("copy", [](WG const & self) -> WG {
+    return WG(self);
+  });
+
+  // hash - for use in Julia Base.hash
+  type.method("hash", [](WG const & self) -> size_t {
+    return self.hash_value();
+  });
+}
+
+}    // namespace libsemigroups_julia

--- a/src/Semigroups.jl
+++ b/src/Semigroups.jl
@@ -95,6 +95,7 @@ export is_undefined, is_positive_infinity, is_negative_infinity, is_limit_max
 # WordGraph
 export WordGraph
 export number_of_nodes, out_degree, number_of_edges
+export target, next_label_and_target, targets
 
 # Transformation types and functions
 export Transf, PPerm, Perm

--- a/src/Semigroups.jl
+++ b/src/Semigroups.jl
@@ -60,6 +60,7 @@ using .Errors: LibsemigroupsError, @wrap_libsemigroups_call
 
 # Julia-side wrapper files
 include("libsemigroups/constants.jl")
+include("libsemigroups/word-graph.jl")
 include("libsemigroups/transf.jl")
 
 # High-level element types
@@ -79,6 +80,10 @@ export enable_debug, is_debug, LibsemigroupsError
 export UNDEFINED, POSITIVE_INFINITY, NEGATIVE_INFINITY, LIMIT_MAX
 export tril, tril_FALSE, tril_TRUE, tril_unknown, tril_to_bool
 export is_undefined, is_positive_infinity, is_negative_infinity, is_limit_max
+
+# WordGraph
+export WordGraph
+export number_of_nodes, out_degree, number_of_edges
 
 # Transformation types and functions
 export Transf, PPerm, Perm

--- a/src/libsemigroups/word-graph.jl
+++ b/src/libsemigroups/word-graph.jl
@@ -1,0 +1,125 @@
+# Copyright (c) 2026, James W. Swent
+#
+# Distributed under the terms of the GPL license version 3.
+#
+# The full license is in the file LICENSE, distributed with this software.
+
+"""
+word-graph.jl - Julia wrappers for libsemigroups WordGraph
+
+This file provides low-level Julia wrappers for the C++ WordGraph<uint32_t>
+class exposed via CxxWrap.
+
+Indices at this layer are **0-based** (matching C++). The high-level
+FroidurePin API will add 1-based conversion when exposing Cayley
+graphs to users.
+"""
+
+# ============================================================================
+# Type alias
+# ============================================================================
+
+"""
+    WordGraph
+
+A word graph (deterministic automaton without initial or accept states).
+Nodes are numbered `0` to `number_of_nodes(g) - 1` and every node has the
+same out-degree.
+
+Construct with `WordGraph(m, n)` for `m` nodes and out-degree `n`.
+"""
+const WordGraph = LibSemigroups.WordGraph
+
+# ============================================================================
+# Size / structure queries
+# ============================================================================
+
+"""
+    number_of_nodes(g::WordGraph) -> Int
+
+Return the number of nodes in the word graph.
+"""
+number_of_nodes(g::WordGraph) = Int(LibSemigroups.number_of_nodes(g))
+
+"""
+    out_degree(g::WordGraph) -> Int
+
+Return the out-degree (number of edge labels) of every node.
+"""
+out_degree(g::WordGraph) = Int(LibSemigroups.out_degree(g))
+
+"""
+    number_of_edges(g::WordGraph) -> Int
+
+Return the total number of defined edges in the word graph.
+"""
+number_of_edges(g::WordGraph) = Int(LibSemigroups.number_of_edges(g))
+
+"""
+    number_of_edges(g::WordGraph, s::Integer) -> Int
+
+Return the number of defined edges with source node `s` (0-based).
+"""
+number_of_edges(g::WordGraph, s::Integer) =
+    Int(LibSemigroups.number_of_edges_node(g, UInt32(s)))
+
+# ============================================================================
+# Edge lookup
+# ============================================================================
+
+"""
+    target(g::WordGraph, source::Integer, label::Integer) -> UInt32
+
+Return the target of the edge from `source` with `label` (both 0-based).
+Returns the C++ `UNDEFINED` value (as `UInt32`) if no such edge exists.
+"""
+target(g::WordGraph, source::Integer, label::Integer) =
+    LibSemigroups.target(g, UInt32(source), UInt32(label))
+
+"""
+    next_label_and_target(g::WordGraph, s::Integer, a::Integer)
+
+Return the next defined edge from node `s` with label >= `a` (both 0-based).
+Returns a `(label, target)` tuple; both are `UNDEFINED` if none found.
+"""
+function next_label_and_target(g::WordGraph, s::Integer, a::Integer)
+    s32, a32 = UInt32(s), UInt32(a)
+    return (LibSemigroups.next_label(g, s32, a32), LibSemigroups.next_target(g, s32, a32))
+end
+
+# ============================================================================
+# Iteration helpers
+# ============================================================================
+
+"""
+    targets(g::WordGraph, source::Integer) -> Vector{UInt32}
+
+Return all edge targets from `source` (0-based) as a vector. Includes
+`UNDEFINED` entries for labels with no defined edge.
+"""
+targets(g::WordGraph, source::Integer) = LibSemigroups.targets_vector(g, UInt32(source))
+
+# ============================================================================
+# Comparison operators
+# ============================================================================
+
+Base.:(==)(a::WordGraph, b::WordGraph) = LibSemigroups.is_equal(a, b)
+Base.:(<)(a::WordGraph, b::WordGraph) = LibSemigroups.is_less(a, b)
+
+# ============================================================================
+# Copy and hash
+# ============================================================================
+
+Base.copy(g::WordGraph) = LibSemigroups.copy(g)
+Base.hash(g::WordGraph, h::UInt) = hash(LibSemigroups.hash(g), h)
+
+# ============================================================================
+# Display
+# ============================================================================
+
+function Base.show(io::IO, g::WordGraph)
+    n = number_of_nodes(g)
+    e = number_of_edges(g)
+    d = out_degree(g)
+    print(io, "WordGraph($n, $d) with $e edges")
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,5 +14,6 @@ using Semigroups
 @testset "Semigroups.jl" begin
     include("test_constants.jl")
     include("test_errors.jl")
+    include("test_word_graph.jl")
     include("test_transf.jl")
 end

--- a/test/test_word_graph.jl
+++ b/test/test_word_graph.jl
@@ -1,0 +1,90 @@
+# Copyright (c) 2026, James W. Swent
+#
+# Distributed under the terms of the GPL license version 3.
+#
+# The full license is in the file LICENSE, distributed with this software.
+
+"""
+test_word_graph.jl - Tests for WordGraph bindings
+"""
+
+@testset "WordGraph type alias" begin
+    @test WordGraph === Semigroups.LibSemigroups.WordGraph
+end
+
+@testset "WordGraph construction" begin
+    g = WordGraph(5, 3)
+    @test number_of_nodes(g) == 5
+    @test out_degree(g) == 3
+    @test number_of_edges(g) == 0  # no edges defined yet
+
+    # Default: zero nodes, zero out-degree
+    g0 = WordGraph(0, 0)
+    @test number_of_nodes(g0) == 0
+    @test out_degree(g0) == 0
+    @test number_of_edges(g0) == 0
+end
+
+@testset "WordGraph number_of_edges per node" begin
+    g = WordGraph(3, 2)
+    # No edges defined, so each node has 0 defined edges
+    for i = 0:2
+        @test number_of_edges(g, i) == 0
+    end
+end
+
+@testset "WordGraph target on empty graph" begin
+    g = WordGraph(3, 2)
+    # All targets should be UNDEFINED
+    for node = 0:2, label = 0:1
+        t = Semigroups.target(g, node, label)
+        @test is_undefined(t, UInt32)
+    end
+end
+
+@testset "WordGraph targets vector" begin
+    g = WordGraph(3, 2)
+    # All targets from node 0 should be UNDEFINED
+    ts = Semigroups.targets(g, 0)
+    @test length(ts) == 2  # out_degree is 2
+    for t in ts
+        @test is_undefined(t, UInt32)
+    end
+end
+
+@testset "WordGraph comparison" begin
+    g1 = WordGraph(3, 2)
+    g2 = WordGraph(3, 2)
+    @test g1 == g2
+
+    g3 = WordGraph(4, 2)
+    @test g1 != g3
+end
+
+@testset "WordGraph copy" begin
+    g1 = WordGraph(3, 2)
+    g2 = copy(g1)
+    @test g1 == g2
+end
+
+@testset "WordGraph hash" begin
+    g1 = WordGraph(3, 2)
+    g2 = WordGraph(3, 2)
+    @test hash(g1) == hash(g2)
+
+    # Can be used in Sets
+    s = Set([g1])
+    @test g2 in s
+end
+
+@testset "WordGraph method signatures" begin
+    @test hasmethod(number_of_nodes, Tuple{WordGraph})
+    @test hasmethod(out_degree, Tuple{WordGraph})
+    @test hasmethod(number_of_edges, Tuple{WordGraph})
+    @test hasmethod(number_of_edges, Tuple{WordGraph,Integer})
+    @test hasmethod(Semigroups.target, Tuple{WordGraph,Integer,Integer})
+    @test hasmethod(Semigroups.next_label_and_target, Tuple{WordGraph,Integer,Integer})
+    @test hasmethod(Semigroups.targets, Tuple{WordGraph,Integer})
+    @test hasmethod(copy, Tuple{WordGraph})
+    @test hasmethod(hash, Tuple{WordGraph,UInt})
+end

--- a/test/test_word_graph.jl
+++ b/test/test_word_graph.jl
@@ -23,32 +23,61 @@ end
     @test number_of_nodes(g0) == 0
     @test out_degree(g0) == 0
     @test number_of_edges(g0) == 0
+
+    # Edge case: single node, zero out-degree
+    g1 = WordGraph(1, 0)
+    @test number_of_nodes(g1) == 1
+    @test out_degree(g1) == 0
+    @test number_of_edges(g1) == 0
+
+    # Edge case: zero nodes with nonzero out-degree
+    g2 = WordGraph(0, 5)
+    @test number_of_nodes(g2) == 0
+    @test out_degree(g2) == 5
+    @test number_of_edges(g2) == 0
 end
 
 @testset "WordGraph number_of_edges per node" begin
     g = WordGraph(3, 2)
-    # No edges defined, so each node has 0 defined edges
-    for i = 0:2
+    # No edges defined, so each node has 0 defined edges (1-based nodes)
+    for i = 1:3
         @test number_of_edges(g, i) == 0
     end
 end
 
 @testset "WordGraph target on empty graph" begin
     g = WordGraph(3, 2)
-    # All targets should be UNDEFINED
-    for node = 0:2, label = 0:1
-        t = Semigroups.target(g, node, label)
-        @test is_undefined(t, UInt32)
+    # All targets should be UNDEFINED (0 in 1-based convention)
+    for node = 1:3, label = 1:2
+        t = target(g, node, label)
+        @test t == 0  # UNDEFINED
     end
 end
 
 @testset "WordGraph targets vector" begin
     g = WordGraph(3, 2)
-    # All targets from node 0 should be UNDEFINED
-    ts = Semigroups.targets(g, 0)
+    # All targets from node 1 should be UNDEFINED (0 in 1-based convention)
+    ts = targets(g, 1)
     @test length(ts) == 2  # out_degree is 2
     for t in ts
-        @test is_undefined(t, UInt32)
+        @test t == 0  # UNDEFINED
+    end
+
+    # Check all nodes
+    for node = 1:3
+        ts = targets(g, node)
+        @test length(ts) == 2
+        @test all(t -> t == 0, ts)
+    end
+end
+
+@testset "WordGraph next_label_and_target on empty graph" begin
+    g = WordGraph(3, 2)
+    # No edges defined, so next_label_and_target should return (0, 0) = UNDEFINED
+    for node = 1:3, label = 1:2
+        lbl, tgt = next_label_and_target(g, node, label)
+        @test lbl == 0  # UNDEFINED
+        @test tgt == 0  # UNDEFINED
     end
 end
 
@@ -59,6 +88,9 @@ end
 
     g3 = WordGraph(4, 2)
     @test g1 != g3
+
+    # Ordering
+    @test (g1 < g3) || (g3 < g1)  # different graphs have an ordering
 end
 
 @testset "WordGraph copy" begin
@@ -75,6 +107,18 @@ end
     # Can be used in Sets
     s = Set([g1])
     @test g2 in s
+
+    # Different graphs should (likely) have different hashes
+    g3 = WordGraph(4, 2)
+    @test hash(g1) != hash(g3)
+end
+
+@testset "WordGraph show" begin
+    g = WordGraph(5, 3)
+    @test sprint(show, g) == "WordGraph(5, 3) with 0 edges"
+
+    g0 = WordGraph(0, 0)
+    @test sprint(show, g0) == "WordGraph(0, 0) with 0 edges"
 end
 
 @testset "WordGraph method signatures" begin
@@ -82,9 +126,9 @@ end
     @test hasmethod(out_degree, Tuple{WordGraph})
     @test hasmethod(number_of_edges, Tuple{WordGraph})
     @test hasmethod(number_of_edges, Tuple{WordGraph,Integer})
-    @test hasmethod(Semigroups.target, Tuple{WordGraph,Integer,Integer})
-    @test hasmethod(Semigroups.next_label_and_target, Tuple{WordGraph,Integer,Integer})
-    @test hasmethod(Semigroups.targets, Tuple{WordGraph,Integer})
+    @test hasmethod(target, Tuple{WordGraph,Integer,Integer})
+    @test hasmethod(next_label_and_target, Tuple{WordGraph,Integer,Integer})
+    @test hasmethod(targets, Tuple{WordGraph,Integer})
     @test hasmethod(copy, Tuple{WordGraph})
     @test hasmethod(hash, Tuple{WordGraph,UInt})
 end


### PR DESCRIPTION
This PR addresses #30 and provides the minimal set of bindings require to instantiate FroidurePin, and lets C++ handle operations on the WordGraph.